### PR TITLE
Minor fixes to 2021 warrant to be valid JSON

### DIFF
--- a/_data/2021warrant.json
+++ b/_data/2021warrant.json
@@ -1891,7 +1891,7 @@
       {
         "comment": "Proposed Amendment by T. Fields",
         "https://www.arlingtonma.gov/home/showdocument?id=55976": "Amendment - T Fields"
-      }
+      },
       {
         "comment": "ARFRR Town Meeting Members' Guide to the Zoning Articles",
         "https://blog-arfrr.blogspot.com/2021/04/town-meeting-members-guide-to-zoning.html": "Arlington Residents For Responsible Redevelopment website"
@@ -2043,7 +2043,7 @@
     "supplements": [
       {
         "comment": "Pay and Classification Plan for town employees",
-        "https://arlington.novusagenda.com/Agendapublic/AttachmentViewer.ashx?AttachmentID=12656&ItemID=11493": "	FY21_Class_and_Pay_Plan_v_Oct_2020.pdf"
+        "https://arlington.novusagenda.com/Agendapublic/AttachmentViewer.ashx?AttachmentID=12656&ItemID=11493": "FY21_Class_and_Pay_Plan_v_Oct_2020.pdf"
       },
       {
         "comment": "That the Classification Plan, as established by Title 1, Article 6, Section 1, Schedule A of the By-Laws, be and hereby is amended as follows: ...",


### PR DESCRIPTION
Hey Shane! 

I'm working on updating the votesmartarlington.com application to include data for 2021, and I noticed a few small issues with the `2021warrant.json` files. As you can see, there was a missing comma in an array of supplement objects and there was a tab-character in a one of the strings, which seemed to cause some issues when parsing the object using the `jq` tool. 

Let me know if you're receptive to these fixes, and if there is anything else I can do to facilitate this PR review!